### PR TITLE
Add cell size constructor for world 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ world.move(bulletItem, newX, newY, bulletCollisionFilter);
 
 `CollisionFilter` may return `Response.slide`, `Response.cross`, `Response.bounce`, `Response.touch`, and `null`.
 
+A value of `null` indicates that `other` will not block movement and will not trigger a `Collision`. Use this for
+entities that do not interact with each other.
+  
+A value of `Response.touch` will stop all movement of `item` and trigger a `Collision`. Use this for entities like 
+arrows that get stuck in the entities they hit.
+
+A value of `Response.slide` will trigger a `Collision` and stop movement in the direction that `item` hits `other`, but 
+will allow it to slide across its surface. This is the typical interaction you would see in a platformer game and is the 
+default `Response`.
+
+A value of `Response.bounce` will trigger a `Collision` and bounce `item` back against the side that it hits `other`.
+This is typically used in games like Breakout where balls bounce against walls and tiles.
+
+A value of `Response.cross` will trigger a `Collision` but will not stop `item` from intersecting `other` and passing 
+through it. This is useful for penetrating bullets and area triggers that are turned on when a player passes through
+them.
+
 ![Bullet](images/shoot.gif?raw=true "bullet")
 
 Get collided items:
@@ -125,4 +142,4 @@ for (int i = 0; i < projectedCollisions.size(); i++) {
 ```
 
 World is in `tileMode` by default. jbump will do additional sorting logic to avoid `Item` getting stuck between tiles.
-You can disable `tileMode` if you are not using tiles for walls to save some circles.
+You can disable `tileMode` if you are not using tiles to increase performance.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 jbump is Java port for bump.lua, a 2D AABB collision detection and response library.
 
 ## Features
-- can be used for Android, iOS (robovm) and normal Java application
-- multiple instances can run on different threads (for server side simulation)
-- safe to repositioning `Item` (must use `world.update`)
+- Can be used for Android, iOS (robovm) and normal Java applications
+- Multiple instances can run on different threads (for server side simulation)
+- Safe to reposition `Item` (must use `world.update`)
 
 ![Tile](images/tile.gif?raw=true "tile")
 
@@ -46,7 +46,7 @@ Using Maven
 
 ## Usage
 
-You must create a `World` object and add `Item`s to it.
+You must create a `World` instance and add `Item` instances to it:
 
 ```Java
 World<Entity> world = new World<Entity>();
@@ -56,16 +56,16 @@ for(Entity obstacle: obstacles) {
 }
 ```
 
-If you want to move an `Item`, call `world.move()`
+If you want to move an `Item`, call `world.move()`:
 
 ```Java
 world.move(item, newX, newY, CollisionFilter.defaultFilter);
 ```
 
-World is in `tileMode` by default. jbump will do additional sorting logic to avoid `Item` get stucked between tiles.
+World is in `tileMode` by default. jbump will do additional sorting logic to avoid `Item` getting stuck between tiles.
 You can disable `tileMode` if you are not using tiles for walls to save some circles.
 
-You can write custom `CollisionFilter`
+You can write a custom `CollisionFilter`:
 
 ```Java
 CollisionFilter bulletCollisionFilter = new CollisionFilter() {
@@ -84,7 +84,7 @@ world.move(bulletItem, newX, newY, unitCollisionFilter);
 
 ![Bullet](images/shoot.gif?raw=true "bullet")
 
-Update `Item` position and size
+Update `Item` position and size:
 ```Java
 world.update(item, newX, newY, newWidth, newHeight);
 world.update(item, newX, newY); // not resize
@@ -92,7 +92,8 @@ world.update(item, newX, newY); // not resize
 
 Available Response: `slide`, `cross` and `touch`.
 
-Get collided items
+Get collided items:
+
 ```Java
 Result result = world.move(item, newX, newY, unitCollisionFilter);
 Collisions projectedCollisions = result.projectedCollisions;
@@ -103,7 +104,8 @@ for (int i = 0; i < projectedCollisions.size(); i++) {
 }
 ```
 
-Store collisions
+Store collisions:
+
 ```
 Result result = world.move(item, newX, newY, unitCollisionFilter);
 Collisions projectedCollisions = result.projectedCollisions;
@@ -113,7 +115,3 @@ for (int i = 0; i < projectedCollisions.size(); i++) {
   collisions.add(col);
 }
 ```
-
-## TODO
-
-- world querying

--- a/README.md
+++ b/README.md
@@ -1,18 +1,22 @@
 # jbump
 
 [![](https://jitpack.io/v/implicit-invocation/jbump.svg)](https://jitpack.io/#implicit-invocation/jbump)  
-jbump is Java port for bump.lua, a 2D AABB collision detection and response library.
+jbump is Java port for bump.lua, a 2D AABB collision detection and response library.  
+Please see the [bump.lua README](https://github.com/kikito/bump.lua/blob/master/README.md) for the original
+documentation.
 
 ## Features
-- Can be used for Android, iOS (robovm) and normal Java applications
+- Simple, fast, and accurate collisions in a lightweight package
+- User has complete control over the movement and physics of entities
+- Can be used for Android, iOS (robovm), and desktop Java applications
 - Multiple instances can run on different threads (for server side simulation)
-- Safe to reposition `Item` (must use `world.update`)
+- Entities can be repositioned and resized during the simulation without errors
 
 ![Tile](images/tile.gif?raw=true "tile")
 
 ## Installation
 
-You can download jar file from https://jitpack.io/com/github/implicit-invocation/jbump/17737e7/jbump-17737e7.jar
+You can download the jar file from https://jitpack.io/com/github/implicit-invocation/jbump/17737e7/jbump-17737e7.jar
 
 Using Gradle
 
@@ -48,7 +52,7 @@ Using Maven
 
 You must create a `World` instance and add `Item` instances to it:
 
-```Java
+```java
 World<Entity> world = new World<Entity>();
 Item<Entity> item = world.add(new Item<Entity>(entity), x, y, w, h);
 for(Entity obstacle: obstacles) {
@@ -56,18 +60,28 @@ for(Entity obstacle: obstacles) {
 }
 ```
 
-If you want to move an `Item`, call `world.move()`:
+To move an `Item` through the World, call `world.move()`:
 
-```Java
+```java
 world.move(item, newX, newY, CollisionFilter.defaultFilter);
 ```
 
-World is in `tileMode` by default. jbump will do additional sorting logic to avoid `Item` getting stuck between tiles.
-You can disable `tileMode` if you are not using tiles for walls to save some circles.
+The above code will simulate movement of the item through the world and generate collisions. The item will be stopped 
+if it collides with another item. To "teleport" an `Item` to a new position without collisions: 
 
-You can write a custom `CollisionFilter`:
+```java
+world.update(item, newX, newY);
+```
 
-```Java
+To also update the size of the `Item`:
+
+```java
+world.update(item, newX, newY, newWidth, newHeight);
+```
+
+To determine what may generate collisions and how they interact with other items, write a custom `CollisionFilter`:
+
+```java
 CollisionFilter bulletCollisionFilter = new CollisionFilter() {
   @Override
   public Response filter(Item item, Item other) {
@@ -79,22 +93,16 @@ CollisionFilter bulletCollisionFilter = new CollisionFilter() {
   }
 };
 ...
-world.move(bulletItem, newX, newY, unitCollisionFilter);
+world.move(bulletItem, newX, newY, bulletCollisionFilter);
 ```
+
+`CollisionFilter` may return `Response.slide`, `Response.cross`, `Response.bounce`, `Response.touch`, and `null`.
 
 ![Bullet](images/shoot.gif?raw=true "bullet")
 
-Update `Item` position and size:
-```Java
-world.update(item, newX, newY, newWidth, newHeight);
-world.update(item, newX, newY); // not resize
-```
-
-Available Response: `slide`, `cross` and `touch`.
-
 Get collided items:
 
-```Java
+```java
 Result result = world.move(item, newX, newY, unitCollisionFilter);
 Collisions projectedCollisions = result.projectedCollisions;
 Array<Item> touched = new Array<Item>();
@@ -106,7 +114,7 @@ for (int i = 0; i < projectedCollisions.size(); i++) {
 
 Store collisions:
 
-```
+```java
 Result result = world.move(item, newX, newY, unitCollisionFilter);
 Collisions projectedCollisions = result.projectedCollisions;
 Collisions collisions = new Collisions();
@@ -115,3 +123,6 @@ for (int i = 0; i < projectedCollisions.size(); i++) {
   collisions.add(col);
 }
 ```
+
+World is in `tileMode` by default. jbump will do additional sorting logic to avoid `Item` getting stuck between tiles.
+You can disable `tileMode` if you are not using tiles for walls to save some circles.

--- a/README.md
+++ b/README.md
@@ -168,5 +168,19 @@ Useful in detecting if the player hit the ground or is pushing against the side 
 * itemRect = The rectangle item occupied when the touch happened
 * otherRect = The rectangle other occupied when the touch happened
 
+## Advanced Settings
+
 World is in `tileMode` by default. jbump will do additional sorting logic to avoid `Item` getting stuck between tiles.
 You can disable `tileMode` if you are not using tiles to increase performance under certain circumstances.
+
+Otherwise, you can fine tune the `cellSize` of each cell used internally to group collisions by implementing the World constructor:
+
+```java
+World<Entity> world = new World<Entity>(32f);
+```
+
+`cellSize` represents the size of the sides of the squared cells that will be used internally to provide the data. 
+This value defaults to 64f, which is fine for most use. However, it should be set to a multiple of your tile size in 
+world units for tile-based games. For example, if you're using pixel units and your tiles are 32x32 pixels, cellSize 
+could be 32f, 64f, 128f, etc. If you're using meters and your tiles are 1x1 meters, cellSize could be 1f, 2f, 4f. Set 
+this value lower/higher to tweak performance.

--- a/jbump/src/com/dongbat/jbump/Grid.java
+++ b/jbump/src/com/dongbat/jbump/Grid.java
@@ -18,7 +18,10 @@ package com.dongbat.jbump;
 import static java.lang.Math.*;
 
 /**
- *
+ * grid_traverse* methods are based on "A Fast Voxel Traversal Algorithm for Ray Tracing",
+ * by John Amanides and Andrew Woo - http://www.cse.yorku.ca/~amana/research/grid.pdf
+ * It has been modified to include both cells when the ray "touches a grid corner",
+ * and with a different exit condition
  * @author tao
  */
 public class Grid {
@@ -72,12 +75,16 @@ public class Grid {
 
     f.onTraverse(cx, cy);
 
+    /*The default implementation had an infinite loop problem when
+    approaching the last cell in some occasions. We finish iterating
+    when we are *next* to the last cell*/
     while (abs(cx - cx2) + abs(cy - cy2) > 1) {
       if (tx < ty) {
         tx = tx + dx;
         cx = cx + stepX;
         f.onTraverse(cx, cy);
       } else {
+        //Addition: include both cells when going through corners
         if (tx == ty) {
           f.onTraverse(cx + stepX, cy);
         }
@@ -87,6 +94,7 @@ public class Grid {
       }
     }
 
+    //If we have not arrived to the last cell, use it
     if (cx != cx2 || cy != cy2) {
       f.onTraverse(cx2, cy2);
     }

--- a/jbump/src/com/dongbat/jbump/Rect.java
+++ b/jbump/src/com/dongbat/jbump/Rect.java
@@ -45,7 +45,13 @@ public class Rect {
   public static void rect_getNearestCorner(float x, float y, float w, float h, float px, float py, Point result) {
     result.set(nearest(px, x, x + w), nearest(y, y, y + h));
   }
-
+  
+  /**
+   * This is a generalized implementation of the liang-barsky algorithm, which also returns
+   * the normals of the sides where the segment intersects.
+   * Notice that normals are only guaranteed to be accurate when initially ti1 == Float.MIN_VALUE, ti2 == Float.MAX_VALUE
+   * @return false if the segment never touches the rect
+   */
   public static boolean rect_getSegmentIntersectionIndices(float x, float y, float w, float h, float x1, float y1, float x2, float y2, float ti1, float ti2, Point ti, IntPoint n1, IntPoint n2) {
     float dx = x2 - x1;
     float dy = y2 - y1;
@@ -56,25 +62,25 @@ public class Rect {
 
     for (int side = 1; side <= 4; side++) {
       switch (side) {
-        case 1:
+        case 1: //left
           nx = -1;
           ny = 0;
           p = -dx;
           q = x1 - x;
           break;
-        case 2:
+        case 2: //right
           nx = 1;
           ny = 0;
           p = dx;
           q = x + w - x1;
           break;
-        case 3:
+        case 3: //top
           nx = 0;
           ny = -1;
           p = -dy;
           q = y1 - y;
           break;
-        default:
+        default: //bottom
           nx = 0;
           ny = 1;
           p = dy;
@@ -112,7 +118,10 @@ public class Rect {
     n2.set(nx2, ny2);
     return true;
   }
-
+  
+  /**
+   * Calculates the minkowsky difference between 2 rects, which is another rect
+   */
   public static void rect_getDiff(float x1, float y1, float w1, float h1, float x2, float y2, float w2, float h2, Rect result) {
     result.set(x2 - x1 - w1, y2 - y1 - h1, w1 + w2, h1 + h2);
   }

--- a/jbump/src/com/dongbat/jbump/RectHelper.java
+++ b/jbump/src/com/dongbat/jbump/RectHelper.java
@@ -54,12 +54,15 @@ public class RectHelper {
     int nx = 0, ny = 0;
 
     if (rect_containsPoint(x, y, w, h, 0, 0)) {
+      //item was intersecting other
       rect_getNearestCorner(x, y, w, h, 0, 0, rect_detectCollision_nearestCorner);
       float px = rect_detectCollision_nearestCorner.x;
       float py = rect_detectCollision_nearestCorner.y;
+  
+      //area of intersection
       float wi = min(w1, abs(px));
       float hi = min(h1, abs(py));
-      ti = -wi * hi;
+      ti = -wi * hi; //ti is the negative area of intersection
       overlaps = true;
     } else {
       boolean intersect = rect_getSegmentIntersectionIndices(x, y, w, h, 0, 0, dx, dy, -Float.MAX_VALUE, Float.MAX_VALUE, rect_detectCollision_getSegmentIntersectionIndices_ti, rect_detectCollision_getSegmentIntersectionIndices_n1, rect_detectCollision_getSegmentIntersectionIndices_n2);
@@ -68,7 +71,8 @@ public class RectHelper {
       int nx1 = rect_detectCollision_getSegmentIntersectionIndices_n1.x;
       int ny1 = rect_detectCollision_getSegmentIntersectionIndices_n1.y;
 
-      if (intersect && ti1 < 1 && abs(ti1 - ti2) >= DELTA
+      //item tunnels into other
+      if (intersect && ti1 < 1 && abs(ti1 - ti2) >= DELTA //special case for rect going through another rect's corner
         && (0 < ti1 + DELTA || 0 == ti1 && ti2 > 0)) {
         ti = ti1;
         nx = nx1;
@@ -83,6 +87,7 @@ public class RectHelper {
 
     if (overlaps) {
       if (dx == 0 && dy == 0) {
+        //intersecting and not moving - use minimum displacement vector
         rect_getNearestCorner(x, y, w, h, 0, 0, rect_detectCollision_nearestCorner);
         float px = rect_detectCollision_nearestCorner.x;
         float py = rect_detectCollision_nearestCorner.y;
@@ -96,6 +101,7 @@ public class RectHelper {
         tx = x1 + px;
         ty = y1 + py;
       } else {
+        //intersecting and moving - move in the opposite direction
         boolean intersect = rect_getSegmentIntersectionIndices(x, y, w, h, 0, 0, dx, dy, -Float.MAX_VALUE, 1, rect_detectCollision_getSegmentIntersectionIndices_ti, rect_detectCollision_getSegmentIntersectionIndices_n1, rect_detectCollision_getSegmentIntersectionIndices_n2);
         float ti1 = rect_detectCollision_getSegmentIntersectionIndices_ti.x;
         nx = rect_detectCollision_getSegmentIntersectionIndices_n1.x;
@@ -107,6 +113,7 @@ public class RectHelper {
         ty = y1 + dy * ti1;
       }
     } else {
+      //tunnel
       tx = x1 + dx * ti;
       ty = y1 + dy * ti;
     }

--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -89,7 +89,7 @@ public class World<E> {
         for (float cx = cl; cx < cl + cw; cx++) {
           if (row.containsKey(cx)) {
             Cell cell = row.get(cx);
-            if (cell.itemCount > 0) {
+            if (cell.itemCount > 0) { //no cell.itemCount > 1 because tunneling
               result.addAll(cell.items);
             }
           }
@@ -145,6 +145,9 @@ public class World<E> {
     if (item != null) {
       visited.add(item);
     }
+    
+    /*This could probably be done with less cells using a polygon raster over the cells instead of a
+    bounding rect of the whole movement. Conditional to building a queryPolygon method*/
     float tl = min(goalX, x);
     float tt = min(goalY, y);
     float tr = max(goalX + w, x + w);

--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -35,7 +35,16 @@ public class World<E> {
   private final Grid grid = new Grid();
   private final RectHelper rectHelper = new RectHelper();
   private boolean tileMode = true;
-
+  private final float cellSize;
+  
+  public World() {
+    this(64f);
+  }
+  
+  public World(float cellSize) {
+    this.cellSize = cellSize;
+  }
+  
   public void setTileMode(boolean tileMode) {
     this.tileMode = tileMode;
   }
@@ -98,8 +107,6 @@ public class World<E> {
     }
     return result;
   }
-
-  private final float cellSize = 64;
 
   private final ArrayList<Cell> getCellsTouchedBySegment_visited = new ArrayList<Cell>();
 
@@ -349,5 +356,9 @@ public class World<E> {
     Response.Result result = check(item, goalX, goalY, filter);
     update(item, result.goalX, result.goalY);
     return result;
+  }
+  
+  public float getCellSize() {
+    return cellSize;
   }
 }

--- a/test/src/com/dongbat/jbump/test/TestBump.java
+++ b/test/src/com/dongbat/jbump/test/TestBump.java
@@ -64,7 +64,7 @@ public class TestBump extends ApplicationAdapter {
         viewport = new ExtendViewport(10, 10, camera);
         shapeDrawer.update();
         
-        world = new World<Entity>();
+        world = new World<Entity>(1f);
         
         entities = new Array<Entity>();
         String[] lines = MAP.split("\n");


### PR DESCRIPTION
Strangely, the author chose not to allow users to set the cellSize of worlds. This is a tool used to tweak performance depending on the size and placement of tiles/walls/etc. This should be important to include for libGDX users who often define their positions using meters instead of pixel units. However, I haven't created a world large enough to see a difference. A stress-test needs to be conducted in the future.