### PR TITLE
Add world querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,25 @@ This value defaults to 64f, which is fine for most use. However, it should be se
 world units for tile-based games. For example, if you're using pixel units and your tiles are 32x32 pixels, cellSize 
 could be 32f, 64f, 128f, etc. If you're using meters and your tiles are 1x1 meters, cellSize could be 1f, 2f, 4f. Set 
 this value lower/higher to tweak performance.
+
+## Querying the World
+
+Instead of checking for collisions with direct bounding box to bounding box tests, you can also use `World` query methods. 
+Arbitrarily positioned point, rectangle, and segment queries are available:
+* Point: `world.queryPoint(x, y, filter, items);`
+* Rectangle: `world.queryRect(x, y, width, height, filter, items);`
+* Segment: `world.querySegment(x1, y1, x2, y2, filter, items);`
+
+`items` is an empty list that will be filled with all the items that collide with the given shape. `filter` is the 
+`CollisionFilter` that defines what items would be tested. Use `CollisionFilter.defaultFilter` to test all items. If 
+you create a custom filter, return null to not accept an item. To accept, return any kind of `Response`. `item` is the 
+item that would be tested. `other` is always null in this case.
+
+A more detailed segment query is available:
+* Segment with Coords: `world.querySegmentWithCoords(x1, y1, x2, y2, filter, infos);`
+
+`infos` is a more detailed list of collision information. The (x1, y1) coordinates of `ItemInfo` define where the 
+segment intersects the `Item`. This is helpful for drawing particle effects where a bullet enters a body, for example. 
+The (x2, y2) coordinates define where the segment exits the item, which is great for drawing an exit wound. (ti1, ti2) 
+are values between 0 and 1 that define how far from the starting point the impact happened. This can be used to 
+describe an effect that weakens with distance.

--- a/jbump/src/com/dongbat/jbump/ItemInfo.java
+++ b/jbump/src/com/dongbat/jbump/ItemInfo.java
@@ -4,7 +4,38 @@ import java.util.Comparator;
 
 public class ItemInfo {
     public Item item;
-    public float x1, y1, x2, y2, ti1, ti2;
+    
+    /**
+     * The x coordinate where the line segment intersects the {@link Rect} of the {@link Item}.
+     */
+    public float x1;
+    
+    /**
+     * The y coordinate where the line segment intersects the {@link Rect} of the {@link Item}.
+     */
+    public float y1;
+    
+    /**
+     * The x coordinate where the line segment exits the {@link Rect} of the {@link Item}. In the case that the segment
+     * does not exit the Rect, this simply returns the coordinate of the segment's end point.
+     */
+    public float x2;
+    
+    /**
+     * The y coordinate where the line segment exits the {@link Rect} of the {@link Item}. In the case that the segment
+     * does not exit the Rect, this simply returns the coordinate of the segment's end point.
+     */
+    public float y2;
+    
+    /**
+     * A value from 0 to 1 indicating how far from the starting point of the segment did the impact happen horizontally.
+     */
+    public float ti1;
+    
+    /**
+     * A value from 0 to 1 indicating how far from the starting point of the segment did the impact happen vertically.
+     */
+    public float ti2;
     public float weight;
     
     public ItemInfo(Item item,  float ti1, float ti2, float weight) {

--- a/jbump/src/com/dongbat/jbump/ItemInfo.java
+++ b/jbump/src/com/dongbat/jbump/ItemInfo.java
@@ -1,0 +1,23 @@
+package com.dongbat.jbump;
+
+import java.util.Comparator;
+
+public class ItemInfo {
+    public Item item;
+    public float x1, y1, x2, y2, ti1, ti2;
+    public float weight;
+    
+    public ItemInfo(Item item,  float ti1, float ti2, float weight) {
+        this.item = item;
+        this.ti1 = ti1;
+        this.ti2 = ti2;
+        this.weight = weight;
+    }
+    
+    public static final Comparator<ItemInfo> weightComparator = new Comparator<ItemInfo>() {
+        @Override
+        public int compare(ItemInfo o1, ItemInfo o2) {
+            return Float.compare(o1.weight, o2.weight);
+        }
+    };
+}

--- a/jbump/src/com/dongbat/jbump/Rect.java
+++ b/jbump/src/com/dongbat/jbump/Rect.java
@@ -49,7 +49,7 @@ public class Rect {
   /**
    * This is a generalized implementation of the liang-barsky algorithm, which also returns
    * the normals of the sides where the segment intersects.
-   * Notice that normals are only guaranteed to be accurate when initially ti1 == Float.MIN_VALUE, ti2 == Float.MAX_VALUE
+   * Notice that normals are only guaranteed to be accurate when initially ti1 == -Float.MAX_VALUE, ti2 == Float.MAX_VALUE
    * @return false if the segment never touches the rect
    */
   public static boolean rect_getSegmentIntersectionIndices(float x, float y, float w, float h, float x1, float y1, float x2, float y2, float ti1, float ti2, Point ti, IntPoint n1, IntPoint n2) {

--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -140,16 +140,16 @@ public class World<E> {
   private final Point info_ti = new Point();
   private final IntPoint info_normalX = new IntPoint();
   private final IntPoint info_normalY = new IntPoint();
+  private final ArrayList<Item> info_visited = new ArrayList<Item>();
   
-  private ArrayList<ItemInfo> getInfoAboutItemsTouchedBySegment(float x1, float y1, float x2, float y2, CollisionFilter filter) {
+  private ArrayList<ItemInfo> getInfoAboutItemsTouchedBySegment(float x1, float y1, float x2, float y2, CollisionFilter filter, ArrayList<ItemInfo> infos) {
+    info_visited.clear();
     getCellsTouchedBySegment(x1, y1, x2, y2, info_cells);
     
-    ArrayList<Item> visited = new ArrayList<Item>();
-    ArrayList<ItemInfo> infos = new ArrayList<ItemInfo>();
     for (Cell cell : info_cells) {
       for (Item item : cell.items) {
-        if (!visited.contains(item)) {
-          visited.add(item);
+        if (!info_visited.contains(item)) {
+          info_visited.add(item);
           if (filter == null || filter.filter(item, null) != null) {
             Rect rect = rects.get(item);
             float l = rect.x;
@@ -422,16 +422,15 @@ public class World<E> {
   
   private final Point query_point = new Point();
   
-  public ArrayList<Item> queryPoint(float x, float y, CollisionFilter filter) {
+  public ArrayList<Item> queryPoint(float x, float y, CollisionFilter filter, ArrayList<Item> items) {
+    items.clear();
     toCell(x, y, query_point);
     float cx = query_point.x;
     float cy = query_point.y;
     LinkedHashSet<Item> dictItemsInCellRect = getDictItemsInCellRect(cx, cy, 1, 1, query_dictItemsInCellRect);
     
-    ArrayList<Item> items = new ArrayList<Item>();
-    Rect rect = new Rect();
     for (Item item : dictItemsInCellRect) {
-      rect = rects.get(item);
+      Rect rect = rects.get(item);
       if ((filter == null || filter.filter(item, null) != null) && rect.rect_containsPoint(rect.x, rect.y, rect.w, rect.h, x, y)) {
         items.add(item);
       }
@@ -439,9 +438,10 @@ public class World<E> {
     return items;
   }
   
-  public ArrayList<Item> querySegment(float x1, float y1, float x2, float y2, CollisionFilter filter) {
-    ArrayList<ItemInfo> infos = getInfoAboutItemsTouchedBySegment(x1, y1, x2, y2, filter);
-    ArrayList<Item> items = new ArrayList<Item>();
+  private final ArrayList<ItemInfo> query_infos = new ArrayList<ItemInfo>();
+  public ArrayList<Item> querySegment(float x1, float y1, float x2, float y2, CollisionFilter filter, ArrayList<Item> items) {
+    items.clear();
+    ArrayList<ItemInfo> infos = getInfoAboutItemsTouchedBySegment(x1, y1, x2, y2, filter, query_infos);
     for (ItemInfo info : infos) {
       items.add(info.item);
     }
@@ -449,8 +449,9 @@ public class World<E> {
     return items;
   }
   
-  public ArrayList<ItemInfo> querySegmentWithCoords(float x1, float y1, float x2, float y2, CollisionFilter filter) {
-    ArrayList<ItemInfo> infos = getInfoAboutItemsTouchedBySegment(x1, y1, x2, y2, filter);
+  public ArrayList<ItemInfo> querySegmentWithCoords(float x1, float y1, float x2, float y2, CollisionFilter filter, ArrayList<ItemInfo> infos) {
+    infos.clear();
+    infos = getInfoAboutItemsTouchedBySegment(x1, y1, x2, y2, filter, infos);
     float dx = x2 - x1;
     float dy = y2 - y1;
     

--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -144,6 +144,7 @@ public class World<E> {
   
   private ArrayList<ItemInfo> getInfoAboutItemsTouchedBySegment(float x1, float y1, float x2, float y2, CollisionFilter filter, ArrayList<ItemInfo> infos) {
     info_visited.clear();
+    infos.clear();
     getCellsTouchedBySegment(x1, y1, x2, y2, info_cells);
     
     for (Cell cell : info_cells) {
@@ -409,9 +410,8 @@ public class World<E> {
     float cl = query_c.x, ct = query_c.y, cw = query_c.w, ch = query_c.h;
     LinkedHashSet<Item> dictItemsInCellRect = getDictItemsInCellRect(cl, ct, cw, ch, query_dictItemsInCellRect);
     
-    Rect rect = new Rect();
     for (Item item : dictItemsInCellRect) {
-      rect = rects.get(item);
+      Rect rect = rects.get(item);
       if ((filter == null || filter.filter(item, null) != null) && rect.rect_isIntersecting(x, y, w, h, rect.x, rect.y, rect.w,rect.h)) {
         items.add(item);
       }

--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -404,6 +404,12 @@ public class World<E> {
   private final Rect query_c = new Rect();
   private final LinkedHashSet<Item> query_dictItemsInCellRect = new LinkedHashSet<Item>();
   
+  /**
+   * A collision check of items that intersect the given rectangle.
+   * @param filter Defines what items will be checked for collision. "item" is the {@link Item} checked for collision.
+   *               "other" is null.
+   * @param items An empty list that will be filled with the {@link Item} instances that collide with the rectangle.
+   */
   public ArrayList<Item> queryRect(float x, float y, float w, float h, CollisionFilter filter, ArrayList<Item> items) {
     items.clear();
     grid.grid_toCellRect(cellSize, x, y, w, h, query_c);
@@ -422,6 +428,12 @@ public class World<E> {
   
   private final Point query_point = new Point();
   
+  /**
+   * A collision check of items that intersect the given point.
+   * @param filter Defines what items will be checked for collision. "item" is the {@link Item} checked for collision.
+   *               "other" is null.
+   * @param items An empty list that will be filled with the {@link Item} instances that collide with the point.
+   */
   public ArrayList<Item> queryPoint(float x, float y, CollisionFilter filter, ArrayList<Item> items) {
     items.clear();
     toCell(x, y, query_point);
@@ -438,6 +450,12 @@ public class World<E> {
     return items;
   }
   
+  /**
+   * A collision check of items that intersect the given line segment.
+   * @param filter Defines what items will be checked for collision. "item" is the {@link Item} checked for collision.
+   *               "other" is null.
+   * @param items An empty list that will be filled with the {@link Item} instances that intersect the segment.
+   */
   private final ArrayList<ItemInfo> query_infos = new ArrayList<ItemInfo>();
   public ArrayList<Item> querySegment(float x1, float y1, float x2, float y2, CollisionFilter filter, ArrayList<Item> items) {
     items.clear();
@@ -449,6 +467,13 @@ public class World<E> {
     return items;
   }
   
+  /**
+   * A collision check of items that intersect the given line segment. Returns more details about where the collision
+   * occurs compared to {@link World#querySegment(float, float, float, float, CollisionFilter, ArrayList)}
+   * @param filter Defines what items will be checked for collision. "item" is the {@link Item} checked for collision.
+   *               "other" is null
+   * @param infos An empty list that will be filled with the collision information.
+   */
   public ArrayList<ItemInfo> querySegmentWithCoords(float x1, float y1, float x2, float y2, CollisionFilter filter, ArrayList<ItemInfo> infos) {
     infos.clear();
     infos = getInfoAboutItemsTouchedBySegment(x1, y1, x2, y2, filter, infos);

--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -330,7 +330,7 @@ public class World<E> {
         for (float cy = ct2; cy <= cb2; cy++) {
           cyOut = cy < ct1 || cy > cb1;
           for (float cx = cl2; cx <= cr2; cx++) {
-            if (cyOut || cx < cl1 || cy > cr1) {
+            if (cyOut || cx < cl1 || cx > cr1) {
               addItemToCell(item, cx, cy);
             }
           }

--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -403,12 +403,12 @@ public class World<E> {
   private final Rect query_c = new Rect();
   private final LinkedHashSet<Item> query_dictItemsInCellRect = new LinkedHashSet<Item>();
   
-  public ArrayList<Item> queryRect(float x, float y, float w, float h, CollisionFilter filter) {
+  public ArrayList<Item> queryRect(float x, float y, float w, float h, CollisionFilter filter, ArrayList<Item> items) {
+    items.clear();
     grid.grid_toCellRect(cellSize, x, y, w, h, query_c);
     float cl = query_c.x, ct = query_c.y, cw = query_c.w, ch = query_c.h;
     LinkedHashSet<Item> dictItemsInCellRect = getDictItemsInCellRect(cl, ct, cw, ch, query_dictItemsInCellRect);
     
-    ArrayList<Item> items = new ArrayList<Item>();
     Rect rect = new Rect();
     for (Item item : dictItemsInCellRect) {
       rect = rects.get(item);

--- a/test/src/com/dongbat/jbump/test/TestBump.java
+++ b/test/src/com/dongbat/jbump/test/TestBump.java
@@ -155,23 +155,23 @@ public class TestBump extends ApplicationAdapter {
         shapeDrawer.setColor(Color.ORANGE);
         shapeDrawer.setDefaultLineWidth(.05f);
         switch (mode) {
-            case POINT:
+            case POINT: //collision check at mouse coordinates
                 world.queryPoint(x, y, CollisionFilter.defaultFilter, items);
                 shapeDrawer.circle(x, y, .1f);
                 break;
-            case RECT:
+            case RECT: //collision check of rectangle centered at mouse coordinates
                 float dimension = debugMagnitude / 360f * DEBUG_MAX_RECT_SIZE;
                 world.queryRect(x - dimension / 2, y - dimension / 2, dimension, dimension, CollisionFilter.defaultFilter, items);
                 shapeDrawer.rectangle(x - dimension / 2, y - dimension / 2, dimension, dimension);
                 break;
-            case SEGMENT:
+            case SEGMENT: //collision check of line segment starting at mouse coordinates
                 tempVector.set(DEBUG_SEGMENT_LENGTH, 0);
                 tempVector.rotate(debugMagnitude);
                 tempVector.add(x, y);
                 world.querySegment(x, y, tempVector.x, tempVector.y, CollisionFilter.defaultFilter, items);
                 shapeDrawer.line(x, y, tempVector.x, tempVector.y);
                 break;
-            case SEGMENT_WITH_COORDS:
+            case SEGMENT_WITH_COORDS: //collision check of line segment with drawing ending at closest collision point
                 tempVector.set(DEBUG_SEGMENT_LENGTH, 0);
                 tempVector.rotate(debugMagnitude);
                 tempVector.add(x, y);

--- a/test/src/com/dongbat/jbump/test/TestBump.java
+++ b/test/src/com/dongbat/jbump/test/TestBump.java
@@ -2,18 +2,26 @@ package com.dongbat.jbump.test;
 
 import com.badlogic.gdx.ApplicationAdapter;
 import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Buttons;
 import com.badlogic.gdx.Input.Keys;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.Pixmap.Format;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
+import com.badlogic.gdx.utils.viewport.ScreenViewport;
 import com.dongbat.jbump.*;
 import com.dongbat.jbump.Response.Result;
 import space.earlygrey.shapedrawer.ShapeDrawer;
+
+import java.util.ArrayList;
+
+import static com.dongbat.jbump.test.TestBump.Mode.*;
 
 /**
  * A runnable game to demonstrate the use and functionality of JBump.
@@ -24,7 +32,8 @@ public class TestBump extends ApplicationAdapter {
     public Texture texture;
     public SpriteBatch spriteBatch;
     public ShapeDrawer shapeDrawer;
-    public ExtendViewport viewport;
+    public ExtendViewport gameViewport;
+    public ScreenViewport uiViewport;
     public OrthographicCamera camera;
     public Array<Entity> entities;
     public static final String MAP =
@@ -39,6 +48,16 @@ public class TestBump extends ApplicationAdapter {
                     "+p----------------+-------------++-----------------------------------------------------------------+\n" +
                     "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++";
     public World<Entity> world;
+    public BitmapFont font;
+    public Mode mode;
+    public enum Mode {
+        POINT, RECT, SEGMENT, SEGMENT_WITH_COORDS
+    }
+    public int debugMagnitude;
+    public static final int DEBUG_VALUE_INCREASE = 15;
+    public static final float DEBUG_MAX_RECT_SIZE = 4f;
+    public static final float DEBUG_SEGMENT_LENGTH = 4f;
+    public static final Vector2 tempVector = new Vector2();
     
     public static void main(String[] args) {
         Lwjgl3ApplicationConfiguration config = new Lwjgl3ApplicationConfiguration();
@@ -57,15 +76,17 @@ public class TestBump extends ApplicationAdapter {
         texture = new Texture(pixmap);
         pixmap.dispose();
         TextureRegion textureRegion = new TextureRegion(texture, 0, 0, 1, 1);
-        
         shapeDrawer = new ShapeDrawer(spriteBatch, textureRegion);
         
         camera = new OrthographicCamera();
-        viewport = new ExtendViewport(10, 10, camera);
+        gameViewport = new ExtendViewport(10, 10, camera);
+        uiViewport = new ScreenViewport();
         shapeDrawer.update();
         
-        world = new World<Entity>(1f);
+        font = new BitmapFont();
+        mode = POINT;
         
+        world = new World<Entity>(1f);
         entities = new Array<Entity>();
         String[] lines = MAP.split("\n");
         for (int j = 0; j < lines.length; j++) {
@@ -91,20 +112,90 @@ public class TestBump extends ApplicationAdapter {
         //draw
         Gdx.gl.glClearColor(0, 0, 0, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
-        
-        viewport.apply();
+        gameViewport.apply();
         spriteBatch.setProjectionMatrix(camera.combined);
         shapeDrawer.update();
         spriteBatch.begin();
         for (Entity entity : entities) {
             entity.draw();
         }
+        
+        //conduct debug test, render shapes, and get text
+        String debugText = conductDebugTest();
+        
+        //draw debug text
+        uiViewport.apply();
+        spriteBatch.setProjectionMatrix(uiViewport.getCamera().combined);
+        font.setColor(Color.RED);
+        font.draw(spriteBatch, debugText, 10f, uiViewport.getWorldHeight() - 10f);
         spriteBatch.end();
+    }
+    
+    public final ArrayList<Item> items = new ArrayList<Item>();
+    public final ArrayList<ItemInfo> infos = new ArrayList<ItemInfo>();
+    
+    public String conductDebugTest() {
+        if (Gdx.input.isButtonJustPressed(Buttons.LEFT)) {
+            mode = Mode.values()[mode.ordinal() == Mode.values().length - 1 ? 0 : mode.ordinal() + 1];
+        }
+        
+        if (Gdx.input.isButtonJustPressed(Buttons.RIGHT)) {
+            debugMagnitude += DEBUG_VALUE_INCREASE;
+            debugMagnitude %= 360;
+        }
+        
+        StringBuilder builder = new StringBuilder("Mouse Coords: (");
+        tempVector.set(Gdx.input.getX(), Gdx.input.getY());
+        builder.append((int) tempVector.x).append(", ").append((int) tempVector.y).append(") Game Coords: (");
+        gameViewport.unproject(tempVector);
+        builder.append(tempVector.x).append(", ").append(tempVector.y).append(")\nMode: ").append(mode).append("\n");
+        float x = tempVector.x;
+        float y = tempVector.y;
+        
+        shapeDrawer.setColor(Color.ORANGE);
+        shapeDrawer.setDefaultLineWidth(.05f);
+        switch (mode) {
+            case POINT:
+                world.queryPoint(x, y, CollisionFilter.defaultFilter, items);
+                shapeDrawer.circle(x, y, .1f);
+                break;
+            case RECT:
+                float dimension = debugMagnitude / 360f * DEBUG_MAX_RECT_SIZE;
+                world.queryRect(x - dimension / 2, y - dimension / 2, dimension, dimension, CollisionFilter.defaultFilter, items);
+                shapeDrawer.rectangle(x - dimension / 2, y - dimension / 2, dimension, dimension);
+                break;
+            case SEGMENT:
+                tempVector.set(DEBUG_SEGMENT_LENGTH, 0);
+                tempVector.rotate(debugMagnitude);
+                tempVector.add(x, y);
+                world.querySegment(x, y, tempVector.x, tempVector.y, CollisionFilter.defaultFilter, items);
+                shapeDrawer.line(x, y, tempVector.x, tempVector.y);
+                break;
+            case SEGMENT_WITH_COORDS:
+                tempVector.set(DEBUG_SEGMENT_LENGTH, 0);
+                tempVector.rotate(debugMagnitude);
+                tempVector.add(x, y);
+                world.querySegmentWithCoords(x, y, tempVector.x, tempVector.y, CollisionFilter.defaultFilter, infos);
+                if (infos.size() == 0) {
+                    shapeDrawer.line(x, y, tempVector.x, tempVector.y);
+                } else {
+                    shapeDrawer.line(x, y, infos.get(0).x1, infos.get(0).y1);
+                }
+                break;
+        }
+        
+        builder.append("items: ").append(items.size());
+        for (Item item : items) {
+            builder.append(", ").append(item.userData.getClass().getSimpleName());
+        }
+        
+        return builder.toString();
     }
     
     @Override
     public void resize(int width, int height) {
-        viewport.update(width, height);
+        gameViewport.update(width, height);
+        uiViewport.update(width, height, true);
         shapeDrawer.update();
     }
     


### PR DESCRIPTION
I added World Querying methods missing from the original jbump implementation. I also resolved a very serious bug that prevented collision detection with items that moved to the right for a distance. I modified the test to demonstrate this new functionality.