### PR TITLE
Added World#reset()

### DIFF
--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -340,6 +340,12 @@ public class World<E> {
       }
     }
   }
+  
+  public void reset() {
+    rects.clear();
+    cellMap.clear();
+    nonEmptyCells.clear();
+  }
 
   public void update(Item item, float x2, float y2) {
     Rect rect = getRect(item);


### PR DESCRIPTION
Adds the ability to reset the world which is woefully lacking in the initial implementation of the lib. This allows reuse of a single world entity instead of creating a new one for every stage.