### PR TITLE
Added ability to retrieve all cells, rects, and items from the world.

### DIFF
--- a/jbump/src/com/dongbat/jbump/World.java
+++ b/jbump/src/com/dongbat/jbump/World.java
@@ -284,7 +284,19 @@ public class World<E> {
   public Rect getRect(Item item) {
     return rects.get(item);
   }
+  
+  public Set<Item> getItems() {
+    return rects.keySet();
+  }
+  
+  public Collection<Rect> getRects() {
+    return rects.values();
+  }
 
+  public Collection<Cell> getCells() {
+    return cellMap.values(); 
+  }
+  
   public int countCells() { 
     return cellMap.size();
   }

--- a/test/src/com/dongbat/jbump/test/TestBump.java
+++ b/test/src/com/dongbat/jbump/test/TestBump.java
@@ -267,6 +267,13 @@ public class TestBump extends ApplicationAdapter {
             if (Gdx.input.isKeyPressed(Keys.S)) {
                 y -= MOVE_SPEED * delta;
             }
+            
+            if (Gdx.input.isKeyJustPressed(Keys.I)) {
+                for (Item item : world.getItems()) {
+                    Entity entity = (Entity) item.userData;
+                    System.out.println(entity.getClass().getSimpleName() + " " + entity.x + " " + entity.y + " " + entity.width + " " + entity.height);
+                }
+            }
     
             Result result = world.move(item, x, y, CollisionFilter.defaultFilter);
             //comment out the following lines to unbind entity position to physics position ------


### PR DESCRIPTION
This adds the ability to retrieve all cells, rects, and items from a world without having to keep track of these elements on your own. I found this to be a lacking feature when I was debugging my levels and could not figure out where unknown items were coming from.